### PR TITLE
Add fail2ban configuration examples

### DIFF
--- a/fail2ban/README.md
+++ b/fail2ban/README.md
@@ -1,12 +1,12 @@
 ## fail2ban configuration examples
 
 RADIUS and RadSec endpoints may see too many failed connection attempts
-due to unknown certificates, protocol errors, and incorrect shared secrets.
-Some of them are caused by misconfiguration of the peers,
-while some others could be potentially dangerous.
+due to unknown certificates, protocol errors, incorrect shared secrets, etc.
+Some are caused by misconfiguration of the peers,
+while some others could be potentially dangerous 
+- a sign of malicious activities.
 These connection failures are not only inflating the log files 
 but also causing port blockage and/or high process load sometimes.
-Some might be a sign of further elaborated attacks.
 
 **[fail2ban](https://github.com/fail2ban/fail2ban)**
 is an intrusion prevention daemon.

--- a/fail2ban/README.md
+++ b/fail2ban/README.md
@@ -3,8 +3,8 @@
 RADIUS and RadSec endpoints may see too many failed connection attempts
 due to unknown certificates, protocol errors, incorrect shared secrets, etc.
 Some are caused by misconfiguration of the peers,
-while some others could be potentially dangerous 
-- a sign of malicious activities.
+while some others could be potentially dangerous - a sign of
+malicious activities.
 These connection failures are not only inflating the log files 
 but also causing port blockage and/or high process load sometimes.
 

--- a/fail2ban/README.md
+++ b/fail2ban/README.md
@@ -1,0 +1,18 @@
+## fail2ban configuration examples
+
+RADIUS and RadSec endpoints may see too many failed connection attempts
+due to unknown certificates, protocol errors, and incorrect shared secrets.
+Some of them are caused by misconfiguration of the peers,
+while some others could be potentially dangerous.
+These connection failures are not only inflating the log files 
+but also causing port blockage and/or high process load sometimes.
+Some might be a sign of further elaborated attacks.
+
+**[fail2ban](https://github.com/fail2ban/fail2ban)**
+is an intrusion prevention daemon.
+Many Linux distributions provide fail2ban package, allowing 
+administrators to enable log-monitoring-based server protection
+easily.
+Here are some configuration example that would be useful 
+for protecting OpenRoaming RadSec endpoints.
+

--- a/fail2ban/README.md
+++ b/fail2ban/README.md
@@ -16,3 +16,17 @@ easily.
 Here are some configuration example that would be useful 
 for protecting OpenRoaming RadSec endpoints.
 
+To see the statistics, 
+
+```
+# fail2ban-client status freeradius
+Status for the jail: freeradius
+|- Filter
+|  |- Currently failed: 1
+|  |- Total failed:     176
+|  `- File list:        /var/log/radius/radius.log
+`- Actions
+   |- Currently banned: 0
+   |- Total banned:     45
+   `- Banned IP list:
+```

--- a/fail2ban/filter.d/freeradius.conf
+++ b/fail2ban/filter.d/freeradius.conf
@@ -1,0 +1,24 @@
+# fail2ban filter for FreeRADIUS
+#
+# Log file to watch is normally /var/log/radius/radius.log
+
+[INCLUDES]
+
+# Read common prefixes. If any customizations available -- read them from
+# common.local
+before = common.conf
+
+[Init]
+maxlines = 2
+
+[Definition]
+
+_daemon = radiusd
+
+failregex = ^.* RADIUS[\/]TLS - Server : Error in error[\r\n]+.* shutting down socket auth\+acct from client \(<HOST>, [0-9]*.*$
+	^.* RADIUS[\/]TLS - Alert read:fatal:unknown CA.*[\r\n]+.* shutting down socket auth\+acct from client \(<HOST>, [0-9]*.*$
+	^.* RADIUS[\/]TLS - Alert read:fatal:certificate unknown.*[\r\n]+.* shutting down socket auth\+acct from client \(<HOST>, [0-9]*.*$
+	^.*Info: Dropping packet.*Received packet from <HOST> with.*Shared secret is incorrect.*$
+
+ignoreregex =
+

--- a/fail2ban/filter.d/freeradius.conf
+++ b/fail2ban/filter.d/freeradius.conf
@@ -15,8 +15,7 @@ maxlines = 2
 
 _daemon = radiusd
 
-failregex = ^.* RADIUS[\/]TLS - Server : Error in error[\r\n]+.* shutting down socket auth\+acct from client \(<HOST>, [0-9]*.*$
-	^.* RADIUS[\/]TLS - Alert read:fatal:unknown CA.*[\r\n]+.* shutting down socket auth\+acct from client \(<HOST>, [0-9]*.*$
+failregex = ^.* RADIUS[\/]TLS - Alert read:fatal:unknown CA.*[\r\n]+.* shutting down socket auth\+acct from client \(<HOST>, [0-9]*.*$
 	^.* RADIUS[\/]TLS - Alert read:fatal:certificate unknown.*[\r\n]+.* shutting down socket auth\+acct from client \(<HOST>, [0-9]*.*$
 	^.*Info: Dropping packet.*Received packet from <HOST> with.*Shared secret is incorrect.*$
 

--- a/fail2ban/jail.local
+++ b/fail2ban/jail.local
@@ -1,0 +1,11 @@
+
+[freeradius]
+enabled = true
+ignoreip = 
+maxretry = 3
+findtime = 60
+bantime = 30m
+port     = 1812,1813,2083
+filter = freeradius
+logpath  = /var/log/radius/radius.log
+


### PR DESCRIPTION
Add fail2ban configuration examples to help OpenRoaming implementers protect their RadSec endpoints.